### PR TITLE
Add actions to run OpenLane

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ using a given tag. Optionally a PR can be created to update a stable tag
 file stored in the repository.
 Arguments:
 -   `ol_tag` [optional, default: `master`]: OpenLane tag. You can set to
-    `ol_tag_file` to use the value from the input.
+    `ol_tag_file` to use the value from the file content.
 -   `update_tag` [optional, default: `false`]: if the test is successful
     update stable tag pointed by the `ol_tag_file` input.
 -   `ol_tag_file` [optional, default: `.github/openlane-stable-tag`]: File
     where to store stable OpenLane tag. The file must exists before running
     with this feature.
--   `tools_list` [optional, default: `''`]: List of the tools to update
-    separated by a space. Example: "openroad_app magic".
+-   `tools_list` [optional, default: `''`]: List of tools to update to the
+    latest version. Multiple values are separated by a space, e.g.,
+    "openroad_app magic".

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ The goal of this action is to run a given design through the OpenLane flow
 using a given tag. Optionally a PR can be created to update a stable tag
 file stored in the repository.
 Arguments:
--   `ol_tag` [optional, default: `latest`]: OpenLane tag. You can set to
+-   `ol_tag` [optional, default: `master`]: OpenLane tag. You can set to
     `ol_tag_file` to use the value from the input.
 -   `update_tag` [optional, default: `false`]: if the test is successful
     update stable tag pointed by the `ol_tag_file` input.
 -   `ol_tag_file` [optional, default: `.github/openlane-stable-tag`]: File
-    where to store stable OpenLane tag.
--   `tools_list` [optional, default: `false`]: List of the tools to update
+    where to store stable OpenLane tag. The file must exists before running
+    with this feature.
+-   `tools_list` [optional, default: `''`]: List of the tools to update
     separated by a space. Example: "openroad_app magic".

--- a/README.md
+++ b/README.md
@@ -67,3 +67,17 @@ public pull request.
 
 Pulls the upstream repository into the local repository.
 
+## [`openlane_run`](./openlane_run)
+
+The goal of this action is to run a given design through the OpenLane flow
+using a given tag. Optionally a PR can be created to update a stable tag
+file stored in the repository.
+Arguments:
+-   `ol_tag` [optional, default: `latest`]: OpenLane tag. You can set to
+    `ol_tag_file` to use the value from the input.
+-   `update_tag` [optional, default: `false`]: if the test is successful
+    update stable tag pointed by the `ol_tag_file` input.
+-   `ol_tag_file` [optional, default: `.github/openlane-stable-tag`]: File
+    where to store stable OpenLane tag.
+-   `tools_list` [optional, default: `false`]: List of the tools to update
+    separated by a space. Example: "openroad_app magic".

--- a/openlane_run/action.yml
+++ b/openlane_run/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: .github/openlane-stable-tag
   tools_list:
     description: List of the tools to update separated by a space. Example "openroad_app magic".
-    default: None
+    default: ''
 
 runs:
   using: composite
@@ -46,7 +46,7 @@ runs:
         git switch -c "$GIT_SHA" "$GIT_SHA"
         # if we are updating any tool, we need to make sure we will use the
         # newly generated docker image
-        if [[ "${{ inputs.tools_list }}" != "None" ]]; then
+        if [[ "${{ inputs.tools_list }}" != "" ]]; then
           GIT_SHA=current
         fi
         echo "OPENLANE_DOCKER_TAG=${GIT_SHA}" >> $GITHUB_ENV
@@ -55,7 +55,7 @@ runs:
         echo '::endgroup::'
 
     - shell: bash
-      if: ${{ inputs.tools_list  != 'None' }}
+      if: ${{ inputs.tools_list }}
       run: |
         echo '::group::Update each tool hash'
         for tool in ${{ inputs.tools_list }}
@@ -68,15 +68,15 @@ runs:
         do
           make -C docker PDK_ROOT=${{ inputs.pdk_path }} "build-${tool}"
         done
-        echo '::endgroup::'
-        echo '::group::Build OpenLane docker image with new tool binary'
-        make -C docker openlane
-        echo '::endgroup::'
 
     - shell: bash
       run: |
         echo '::group::Get PDKs'
         make pdk
+        echo '::endgroup::'
+        echo '::endgroup::'
+        echo '::group::Get OpenLane docker'
+        make -C docker get-openlane
         echo '::endgroup::'
         echo '::group::Run design using OpenLane'
         make TEST_DESIGN=gha_design test

--- a/openlane_run/action.yml
+++ b/openlane_run/action.yml
@@ -1,0 +1,120 @@
+name: Run design with OpenLane.
+
+description: >
+  The goal of this action is to run a given design through the OpenLane flow
+  using a given tag. Optionally a PR can be created to update a stable tag
+  file stored in the repository.
+
+inputs:
+  ol_tag:
+    description: OpenLane tag. You can set to ol_tag_file to use the value from the input.
+    default: master
+  update_tag:
+    description: If the test is successful update stable tag pointed by the ol_tag_file input.
+    default: false
+  ol_tag_file:
+    description: File where to store the new OpenLane tag
+    default: .github/openlane-stable-tag
+  tools_list:
+    description: List of the tools to update separated by a space. Example "openroad_app magic".
+    default: None
+
+runs:
+  using: composite
+  steps:
+
+    - uses: actions/checkout@v3
+      with:
+        repository: The-OpenROAD-Project/OpenLane
+        fetch-depth: 0
+
+    - uses: actions/checkout@v3
+      with:
+        path: designs/gha_design
+
+    - shell: bash
+      run: |
+        echo '::group::Export variables to use with OpenLane Makefile'
+        if [[ "${{ inputs.ol_tag }}" == "ol_tag_file" ]]; then
+          GIT_SHA="$(cat designs/gha_design/${{ inputs.ol_tag_file }})"
+        elif [[ "${{ inputs.ol_tag }}" == "master" ]]; then
+          GIT_SHA="$(git describe --exact-match --tags $(git rev-list --tags --max-count=1))"
+        else
+          GIT_SHA=${{ inputs.ol_tag }}
+        fi
+        echo "Checkout correct branch: $GIT_SHA"
+        git switch -c "$GIT_SHA" "$GIT_SHA"
+        # if we are updating any tool, we need to make sure we will use the
+        # newly generated docker image
+        if [[ "${{ inputs.tools_list }}" != "None" ]]; then
+          GIT_SHA=current
+        fi
+        echo "OPENLANE_DOCKER_TAG=${GIT_SHA}" >> $GITHUB_ENV
+        echo "OPENLANE_IMAGE_NAME=efabless/openlane:${GIT_SHA}" >> $GITHUB_ENV
+        echo "PDK_ROOT=${PWD}/pdks" >> $GITHUB_ENV
+        echo '::endgroup::'
+
+    - shell: bash
+      if: ${{ inputs.tools_list  != 'None' }}
+      run: |
+        echo '::group::Update each tool hash'
+        for tool in ${{ inputs.tools_list }}
+        do
+          python3 .github/scripts/update_tools.py "${tool}"
+        done
+        echo '::endgroup::'
+        echo '::group::Build docker image for each updated tool'
+        for tool in ${{ inputs.tools_list }}
+        do
+          make -C docker PDK_ROOT=${{ inputs.pdk_path }} "build-${tool}"
+        done
+        echo '::endgroup::'
+        echo '::group::Build OpenLane docker image with new tool binary'
+        make -C docker openlane
+        echo '::endgroup::'
+
+    - shell: bash
+      run: |
+        echo '::group::Get PDKs'
+        make pdk
+        echo '::endgroup::'
+        echo '::group::Run design using OpenLane'
+        make TEST_DESIGN=gha_design test
+        echo '::endgroup::'
+
+    - shell: bash
+      id: tag_check
+      if: ${{ inputs.update_tag  }}
+      run: |
+        echo '::group::Update OpenLane stable tag file'
+        if [[ "$(cat designs/gha_design/${{ inputs.ol_tag_file }})" == "${OPENLANE_DOCKER_TAG}" ]]; then
+          echo '::set-output name=tag_changed::false'
+          echo 'Did not update tag file.'
+        else
+          echo "${OPENLANE_DOCKER_TAG}" > designs/gha_design/${{ inputs.ol_tag_file }}
+          echo '::set-output name=tag_changed::true'
+          echo 'Did update tag file, can create PR.'
+        fi
+        echo '::endgroup::'
+
+    - uses: peter-evans/create-pull-request@v4
+      id: cpr
+      if: ${{ inputs.update_tag && steps.tag_check.outputs.tag_changed }}
+      with:
+        path: designs/gha_design
+        add-path: ${{ inputs.ol_tag_file }}
+        title: '[BOT] Update OpenLane stable tag.'
+        body: |
+          This is an automated PR.
+          See the individual commits for details.
+        commit-message: |
+          [BOT] Update OpenLane stable tag -> ${{ env.OPENLANE_DOCKER_TAG }}
+        branch: update-openlane-tag
+        draft: true
+        delete-branch: true
+
+    - shell: bash
+      if: ${{ steps.cpr.outputs.pull-request-number }}
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Usage is shown here: https://github.com/The-OpenROAD-Project/actions-test/actions
These actions allow users to test their designs with a stable and the latest version of OpenLane as well as the latest version of OpenROAD.

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>