### PR TITLE
Kill ssh-agent as cleanup

### DIFF
--- a/upstream_sync/action.yml
+++ b/upstream_sync/action.yml
@@ -56,8 +56,9 @@ runs:
         repo
       cd repo
       # Start ssh agent and add deploy key.
-      eval $(ssh-agent -s)
+      SSH_AGENT_PID=$(eval $(ssh-agent -s) | awk '{print $3}')
       ssh-add - <<< "${{ inputs.deployKey }}"
       # Add local repository and push to it.
       git remote add origin git+ssh://git@github.com/${{ github.repository }}.git
       git push origin $GIT_ARGS --verbose upstream/${{ inputs.upstreamBranch }}:${{ inputs.upstreamBranch }}
+      kill $SSH_AGENT_PID


### PR DESCRIPTION
When this action runs on self-hosted agents it always creates a
ssh-agent process, which unattended can lead to resource starvation.

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>