### PR TITLE
PRs created from upstream are not Draft

### DIFF
--- a/send_pr/action.py
+++ b/send_pr/action.py
@@ -60,7 +60,7 @@ def send_pr():
             "title": event_json["pull_request"]["title"],
             "body": event_json["pull_request"]["body"],
             "maintainer_can_modify": True,
-            "draft": True,
+            "draft": False,
         }
         r = send_github_json(pr_api_url, "POST", create_pr_json)
         print(f"::group::Created pull request from {staging.slug} {staging.branch} to {upstream.slug}")


### PR DESCRIPTION
We will stop running Draft PRs in the CI.
This will ensure that PRs from upstream are run in the CI automatically.