### PR TITLE
Fixed use of unnassigned variable bug in send_pr action

### DIFF
--- a/send_pr/action.py
+++ b/send_pr/action.py
@@ -77,7 +77,7 @@ def send_pr():
         print("Pull request already existed!")
         print()
 
-    upstream.pr = new_pr_number
+    upstream.pr = prs_json[-1]["number"]
 
     print()
     print("Private PR:", private.pr, private.pr_url)


### PR DESCRIPTION
In case `prs_json` is nil, `new_pr_number` never gets initialized so the assignment `upstream.pr = new_pr_number` was throwing.