### PR TITLE
gha: use commit sha instead of version/tag

### DIFF
--- a/openlane_run/action.yml
+++ b/openlane_run/action.yml
@@ -23,12 +23,12 @@ runs:
   using: composite
   steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
       with:
         repository: The-OpenROAD-Project/OpenLane
         fetch-depth: 0
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
       with:
         path: designs/gha_design
 
@@ -97,7 +97,7 @@ runs:
         fi
         echo '::endgroup::'
 
-    - uses: peter-evans/create-pull-request@v4
+    - uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54  # v4.2.4
       id: cpr
       if: ${{ inputs.update_tag == 'true' && steps.tag_check.outputs.tag_changed == 'true' }}
       with:


### PR DESCRIPTION
Using commit sha helps prevent chain attacks that have become common.